### PR TITLE
add @importFrom futile.logger appender.console

### DIFF
--- a/R/logger.R
+++ b/R/logger.R
@@ -66,6 +66,7 @@
 #' @importFrom R6 R6Class
 #' @importFrom futile.logger flog.error flog.warn flog.info flog.debug
 #' @importFrom futile.logger flog.appender 
+#' @importFrom futile.logger appender.console appender.file
 #' @format A \code{\link{R6Class}} object
 #' 
 #' @export


### PR DESCRIPTION
I believe RlyLogger forgot to import appender.console and appender.file from futile.logger in its document. When I invoke functions in rly from my R package, it returned

could not find function "appender.console"

error.